### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/tmsincomb/6436dc20-43de-4df2-ba8d-aad565e7a5ad/8973c44f-745c-40c5-af85-3386c78c77c5/_apis/work/boardbadge/8bcb1106-1423-43b0-b683-bf478481b585)](https://dev.azure.com/tmsincomb/6436dc20-43de-4df2-ba8d-aad565e7a5ad/_boards/board/t/8973c44f-745c-40c5-af85-3386c78c77c5/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#1](https://dev.azure.com/tmsincomb/6436dc20-43de-4df2-ba8d-aad565e7a5ad/_workitems/edit/1). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.